### PR TITLE
Rgdal

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ BugReports: https://github.com/ropensci/slopes/issues
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.3.2
 Imports: 
     sf,
     raster,
@@ -51,7 +51,6 @@ Suggests:
     osmextract,
     stplanr,
     dplyr,
-    rgdal,
     tmap,
     leaflet,
     bench

--- a/vignettes/roadnetworkcycling.Rmd
+++ b/vignettes/roadnetworkcycling.Rmd
@@ -195,6 +195,7 @@ st_write(network, "shapefiles/SlopesIoW.gpkg", append=F)
 -   [Oporto (Portugal)](https://web.tecnico.ulisboa.pt/~rosamfelix/gis/declives/DeclivesPorto_EU.html)
 -   [Leeds (UK)](https://web.tecnico.ulisboa.pt/~rosamfelix/gis/declives/SlopesLeeds.html)
 -   [Zurich (CH)](https://web.tecnico.ulisboa.pt/~rosamfelix/gis/declives/SlopesZurich.html)
+-   [Paris (FR)](https://web.tecnico.ulisboa.pt/~rosamfelix/gis/declives/SlopesParis_NASA.html)
 
 
 ```{r tidyup, include=FALSE}


### PR DESCRIPTION
remove rgdal of suggests
use up-to-date version of roxygen

add Paris case study (this was on my previous commits, sorry for mixing it up here)