### PR TITLE
#50 elevation_add() error fix

### DIFF
--- a/R/slope_get.R
+++ b/R/slope_get.R
@@ -48,8 +48,7 @@ elevation_get = function(routes, ..., output_format = "raster") {
   if(!requireNamespace("terra", quietly = TRUE)) {
     message('install.packages("terra") # for this to work')
   }
-  et = terra::rast(e)
-  res = terra::project(et, y = crs_routes$wkt)
+  res = terra::project(e, y = crs_routes$wkt)
   if(output_format == "raster") {
     res = raster::raster(res)
   }


### PR DESCRIPTION
Implementation of fix suggested at https://github.com/ropensci/slopes/issues/50#issuecomment-2909826136.

I think that the problem was at `slopes::elevation_get()`, when calling `terra::rast()` over an object that was already a SpatRast, returned previously by `ceramic::cc_elevation`. This reconversion was unnecessary and causing the SpatRast to loose important attributes that generate the error when missing.