### PR TITLE
Fix CRAN donttest failure (fixes #72)

### DIFF
--- a/R/slopes.R
+++ b/R/slopes.R
@@ -228,6 +228,22 @@ elevation_extract <- function(m, dem, method = "bilinear", terra = has_terra() &
 #' @param terra Logical, whether to use terra package (default: auto-detected)
 #' @return An sf object with XYZ linestring geometries
 #' @export
+#' @examples
+#' library(sf)
+#' routes = lisbon_road_network[204, ]
+#' dem = dem_lisbon_raster
+#' (r3d = elevation_add(routes, dem))
+#' st_z_range(routes)
+#' st_z_range(r3d)
+#' plot(st_coordinates(r3d)[, 3])
+#' plot_slope(r3d)
+#' \dontrun{
+#' # Get elevation data (requires internet connection, ceramic pkg, and API key):
+#' if (requireNamespace("ceramic", quietly = TRUE)) {
+#'   r3d_get = elevation_add(cyclestreets_route)
+#'   plot_slope(r3d_get)
+#' }
+#' }
 elevation_add <- function(routes, dem = NULL, method = "bilinear", terra = has_terra() && methods::is(dem, "SpatRaster")) {
   stopifnotsf(routes)
   if (is.null(dem)) {

--- a/man/elevation_add.Rd
+++ b/man/elevation_add.Rd
@@ -26,3 +26,20 @@ An sf object with XYZ linestring geometries
 \description{
 Adds elevation (Z) coordinates to linestring geometries using DEM data.
 }
+\examples{
+library(sf)
+routes = lisbon_road_network[204, ]
+dem = dem_lisbon_raster
+(r3d = elevation_add(routes, dem))
+st_z_range(routes)
+st_z_range(r3d)
+plot(st_coordinates(r3d)[, 3])
+plot_slope(r3d)
+\dontrun{
+# Get elevation data (requires internet connection, ceramic pkg, and API key):
+if (requireNamespace("ceramic", quietly = TRUE)) {
+  r3d_get = elevation_add(cyclestreets_route)
+  plot_slope(r3d_get)
+}
+}
+}


### PR DESCRIPTION
This PR fixes the CRAN check failure that led to the package being archived on 2026-05-24.

## Changes

- Restores  for  with local DEM examples that don't require external dependencies
- Wraps the ceramic-dependent example in  instead of  —  is never executed on CRAN's 
- Adds  guard for extra safety

## Background

CRAN's  flag executes  blocks. The previous example called  which triggers  requiring the  package and a Mapbox API key, causing:



This fix follows the same pattern already used in  documentation.

Closes #72